### PR TITLE
Update deprecated security filter chain notation

### DIFF
--- a/src/main/java/dev/danvega/jwt/config/SecurityConfig.java
+++ b/src/main/java/dev/danvega/jwt/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                         .anyRequest().hasAuthority("SCOPE_READ")
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
+                .oauth2ResourceServer((oauth2)->oauth2.jwt(Customizer.withDefaults()))
                 .httpBasic(withDefaults())
                 .build();
     }


### PR DESCRIPTION
Former version is deprecated and marked to delete 6.1