### PR TITLE
Use proper algorithm name in SecretKeySpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ return this.encoder.encode(encoderParameters).getTokenValue();
 @Bean
 public JwtDecoder jwtDecoder() {
     byte[] bytes = jwtKey.getBytes();
-    SecretKeySpec originalKey = new SecretKeySpec(bytes, 0, bytes.length,"RSA");
+    SecretKeySpec originalKey = new SecretKeySpec(bytes, 0, bytes.length, "HmacSHA256");
     return NimbusJwtDecoder.withSecretKey(originalKey).macAlgorithm(MacAlgorithm.HS512).build();
 }
 ```

--- a/src/main/java/dev/danvega/jwt/config/SecurityConfig.java
+++ b/src/main/java/dev/danvega/jwt/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
     @Bean
     public JwtDecoder jwtDecoder() {
         byte[] bytes = jwtKey.getBytes();
-        SecretKeySpec originalKey = new SecretKeySpec(bytes, 0, bytes.length,"RSA");
+        SecretKeySpec originalKey = new SecretKeySpec(bytes, 0, bytes.length, "HmacSHA256");
         return NimbusJwtDecoder.withSecretKey(originalKey).macAlgorithm(MacAlgorithm.HS512).build();
     }
 


### PR DESCRIPTION
It seems there was copy-paste mistake and `"HmacSHA256"` should be used instead of `"RSA"` (this is Java name for `HS512` as per [Java Security Standard Algorithm Names](https://docs.oracle.com/en/java/javase/21/docs/specs/security/standard-names.html) document).

I analyzed it a bit and commented in the Stack Overflow thread mentioning the tutorial: https://stackoverflow.com/a/79423813/4774651.

Thanks for this example 👍🏻 couldn't find many symmetric key tutorials.